### PR TITLE
Fix android device and inode types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,20 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 9 * * MON'
+
 
 jobs:
   build:
     name: Build and test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         rust: ["1.40.0", stable]
@@ -27,6 +35,32 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
+
+  build_extra:
+    name: Build on extra platforms
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - arm-unknown-linux-gnueabihf
+          - aarch64-unknown-linux-gnu
+          - aarch64-linux-android
+          - i686-linux-android
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+          default: true
+          profile: minimal
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target ${{ matrix.target }}
+          use-cross: true
 
   rustfmt:
     name: Check rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default = ["serde"]
 
 [dependencies]
 serde = { version = "1.0.117", optional = true, features = ["derive"] }
+cfg-if = "1.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
 nix = "0.19.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,22 +21,21 @@
 #![deny(missing_docs)]
 #![warn(clippy::pedantic)]
 
-#[cfg(unix)]
-mod clircle_unix;
-#[cfg(unix)]
-pub use clircle_unix::{nix, UnixIdentifier};
-
-#[cfg(windows)]
-mod clircle_windows;
-#[cfg(windows)]
-pub use clircle_windows::{winapi, WindowsIdentifier};
-
-#[cfg(unix)]
-/// Identifies a file. The type is aliased according to the target platform.
-pub type Identifier = UnixIdentifier;
-#[cfg(windows)]
-/// Identifies a file. The type is aliased according to the target platform.
-pub type Identifier = WindowsIdentifier;
+cfg_if::cfg_if! {
+    if #[cfg(unix)] {
+        mod clircle_unix;
+        pub use clircle_unix::{nix, UnixIdentifier};
+        /// Identifies a file. The type is aliased according to the target platform.
+        pub type Identifier = UnixIdentifier;
+    } else if #[cfg(windows)] {
+        mod clircle_windows;
+        pub use clircle_windows::{winapi, WindowsIdentifier};
+        /// Identifies a file. The type is aliased according to the target platform.
+        pub type Identifier = WindowsIdentifier;
+    } else {
+        compile_error!("Neither cfg(unix) nor cfg(windows) was true, aborting.");
+    }
+}
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Related to #2 

This introduces compile time logic to correctly type the fields of UnixIdentifier on mobile platforms.
