### PR TITLE
Update nix to 0.24.1, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,7 @@ winapi = { version = "0.3.9", features = ["winnt", "winbase", "processenv", "han
 [dev-dependencies]
 tempfile = "3.1.0"
 
-[target.'cfg(not(windows))'.dev-dependencies]
-nix = "0.19.1"
+[target.'cfg(not(windows))'.dev-dependencies.nix]
+version = "0.24.1"
+default-features = false
+features = ["term"]


### PR DESCRIPTION
This reduces test build times slightly.