### PR TITLE
Bump MSRV & allow `serde` and `serde_derive` to compile in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: ["1.56.0", stable]
+        rust: ["1.60.0", stable]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "clircle"
 version = "0.4.0"
 authors = ["Niklas Mohrin <niklas.mohrin@gmail.com>"]
 license = "MIT OR Apache-2.0"
-rust-version = "1.56"
+rust-version = "1.60"
 edition = "2021"
 description = "Detect IO circles in your CLI apps arguments."
 homepage = "https://github.com/niklasmohrin/clircle"
@@ -15,9 +15,11 @@ keywords = ["cycle", "arguments", "argv", "io"]
 
 [features]
 default = ["serde"]
+serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
-serde = { version = "1.0.117", optional = true, features = ["derive"] }
+serde = { version = "1.0.117", optional = true }
+serde_derive = { version = "1.0.117", optional = true }
 cfg-if = "1.0.0"
 
 [target.'cfg(not(windows))'.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/niklasmohrin/clircle/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/niklasmohrin/clircle/actions/workflows/ci.yml)
 [![crates.io version](https://img.shields.io/crates/v/clircle)](https://crates.io/crates/clircle)
-[![MSRV](https://img.shields.io/badge/MSRV-1.56.0-blue)](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
+[![MSRV](https://img.shields.io/badge/MSRV-1.60.0-blue)](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html)
 
 Clircle provides a cross-platform API to detect read / write cycles from your
 user-supplied arguments. You can get the important identifiers of a file (from

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ cfg_if::cfg_if! {
 }
 
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::fs::File;
 


### PR DESCRIPTION
Visualized in `cargo build --timings`:

| Before: | After: |
|---|---|
| <img src="https://github.com/niklasmohrin/clircle/assets/1940490/0d74dd42-1afc-4320-9592-4460432e1ec7" width="350"> | <img src="https://github.com/niklasmohrin/clircle/assets/1940490/9af4aced-1ad1-41f5-8301-01ad8e985fa7" width="350"> |

Previously `serde` could only begin compiling after `serde_derive` was finished compiling. After, they can compile in parallel.

This reduces build time by 2 seconds (36%).